### PR TITLE
Remove placeholder row when table has no data

### DIFF
--- a/DocXToPdfConverter/DocXToPdfHandlers/DocXHandler.cs
+++ b/DocXToPdfConverter/DocXToPdfHandlers/DocXHandler.cs
@@ -213,14 +213,11 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
 
                             }
 
-                            if (j < trCol0.Value.Length - 1)
-                            {
-                                tableRow.Parent.InsertAfter(tableRowCopy, tableRow);
-                                tableRow = tableRowCopy;
-                            }
-                            
+                            tableRow.Parent.InsertAfter(tableRowCopy, tableRow);
+                            tableRow = tableRowCopy;
                         }
 
+                        tableRow.Remove();
                     }
 
 


### PR DESCRIPTION
Previous behaviour : when a TablePlaceholder contained no data, the output file still showed the row with the placeholders. IMO, there should be no row at all in this case.

New behaviour : a TablePlaceholder with no data results in 0 row in the output file.