### PR TITLE
Add option to process docx files in compatibility mode

### DIFF
--- a/DocXToPdfConverter/DocXToPdfConverter.csproj
+++ b/DocXToPdfConverter/DocXToPdfConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/DocXToPdfConverter/DocXToPdfConverter.csproj
+++ b/DocXToPdfConverter/DocXToPdfConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/DocXToPdfConverter/DocXToPdfConverter.csproj
+++ b/DocXToPdfConverter/DocXToPdfConverter.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.10.0-beta0002" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.15.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
   </ItemGroup>
 

--- a/DocXToPdfConverter/DocXToPdfHandlers/ConvertWithLibreOffice.cs
+++ b/DocXToPdfConverter/DocXToPdfHandlers/ConvertWithLibreOffice.cs
@@ -93,14 +93,6 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
             procStartInfo.WorkingDirectory = Environment.CurrentDirectory;
 
             var process = new Process() { StartInfo = procStartInfo };
-            Process[] pname = Process.GetProcessesByName("soffice");
-
-            //Supposedly, only one instance of Libre Office can be run simultaneously
-            while (pname.Length > 0)
-            {
-                Thread.Sleep(5000);
-                pname = Process.GetProcessesByName("soffice");
-            }
 
             process.Start();
             process.WaitForExit();

--- a/DocXToPdfConverter/DocXToPdfHandlers/DocXHandler.cs
+++ b/DocXToPdfConverter/DocXToPdfHandlers/DocXHandler.cs
@@ -25,12 +25,17 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
         private readonly MemoryStream _docxMs;
         private readonly Placeholders _rep;
         private int _imageCounter;
+        private readonly OpenSettings _openSettings = new OpenSettings() { AutoSave = true };
 
-        public DocXHandler(string docXTemplateFilename, Placeholders rep)
+
+        public DocXHandler(string docXTemplateFilename, Placeholders rep, bool office2007Compatible)
         {
             _docxMs = StreamHandler.GetFileAsMemoryStream(docXTemplateFilename);
             _rep = rep;
-
+            if (office2007Compatible)
+            {
+                _openSettings.MarkupCompatibilityProcessSettings = new MarkupCompatibilityProcessSettings(MarkupCompatibilityProcessMode.ProcessLoadedPartsOnly, FileFormatVersions.Office2007);
+            }
         }
 
 
@@ -58,7 +63,7 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
             if (_rep.TextPlaceholders == null || _rep.TextPlaceholders.Count == 0)
                 return null;
 
-            using (var doc = WordprocessingDocument.Open(_docxMs, true))
+            using (var doc = WordprocessingDocument.Open(_docxMs, true, _openSettings))
             {
                 CleanMarkup(doc);
 
@@ -121,7 +126,7 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
             if (_rep.HyperlinkPlaceholders == null || _rep.HyperlinkPlaceholders.Count == 0)
                 return null;
 
-            using (var doc = WordprocessingDocument.Open(_docxMs, true))
+            using (var doc = WordprocessingDocument.Open(_docxMs, true, _openSettings))
             {
                 CleanMarkup(doc);
 
@@ -206,7 +211,7 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
             if (_rep.TablePlaceholders == null || _rep.TablePlaceholders.Count == 0)
                 return null;
 
-            using (var doc = WordprocessingDocument.Open(_docxMs, true))
+            using (var doc = WordprocessingDocument.Open(_docxMs, true, _openSettings))
             {
                 CleanMarkup(doc);
 
@@ -302,7 +307,7 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
             if (_rep.ImagePlaceholders == null || _rep.ImagePlaceholders.Count == 0)
                 return null;
 
-            using (var doc = WordprocessingDocument.Open(_docxMs, true))
+            using (var doc = WordprocessingDocument.Open(_docxMs, true, _openSettings))
             {
                 CleanMarkup(doc);
 
@@ -426,7 +431,8 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
                     new DW.EffectExtent { LeftEdge = 0L, TopEdge = 0L, RightEdge = 0L, BottomEdge = 0L },
                     new DW.DocProperties { Id = (UInt32Value)1U, Name = pictureName + _imageCounter },
                     new DW.NonVisualGraphicFrameDrawingProperties(
-                    new A.GraphicFrameLocks { NoChangeAspect = true }),
+                        new A.GraphicFrameLocks { NoChangeAspect = true }
+                        ),
                     new A.Graphic(
                         new A.GraphicData(
                             new PIC.Picture(

--- a/DocXToPdfConverter/ReportGenerator.cs
+++ b/DocXToPdfConverter/ReportGenerator.cs
@@ -21,11 +21,18 @@ namespace DocXToPdfConverter
     {
         private readonly string _locationOfLibreOfficeSoffice;
 
-        // If you dont need conversion to PDF, you can leave the LocationOfLibreOfficeSoffice empty 
-        // For Windows users: this must point to the ".exe" file, so \Path\Path\soffice.exe
-        public ReportGenerator(string locationOfLibreOfficeSoffice = "")
+        private readonly bool _processOffice2007Compatible;
+
+
+        /// <summary>
+        /// ReportGenerator is the main class to convert documents
+        /// </summary>
+        /// <param name="locationOfLibreOfficeSoffice">If you dont need conversion to PDF, you can leave the LocationOfLibreOfficeSoffice empty. For Windows users: this must point to the ".exe" file, so \Path\Path\soffice.exe</param>
+        /// <param name="processOffice2007Compatible">If set to true, then docx documents are generated in a Office2007 compatible way. Default is false, then no processing is done.</param>
+        public ReportGenerator(string locationOfLibreOfficeSoffice = "", bool processOffice2007Compatible = false)
         {
             _locationOfLibreOfficeSoffice = locationOfLibreOfficeSoffice;
+            _processOffice2007Compatible = processOffice2007Compatible;
         }
 
         public void Convert(string inputFile, string outputFile, Placeholders rep = null)
@@ -96,7 +103,7 @@ namespace DocXToPdfConverter
 
         private void PrintDocx(string templateFile, string printername, Placeholders rep)
         {
-            var docx = new DocXHandler(templateFile, rep);
+            var docx = new DocXHandler(templateFile, rep, _processOffice2007Compatible);
             var ms = docx.ReplaceAll();
             var tempFileToPrint = Path.ChangeExtension(Path.GetTempFileName(), ".docx");
             StreamHandler.WriteMemoryStreamToDisk(ms, tempFileToPrint);
@@ -119,7 +126,7 @@ namespace DocXToPdfConverter
         //string docxSource = filename with path
         private void GenerateReportFromDocxToDocX(string docxSource, string docxTarget, Placeholders rep)
         {
-            var docx = new DocXHandler(docxSource, rep);
+            var docx = new DocXHandler(docxSource, rep, _processOffice2007Compatible);
             var ms = docx.ReplaceAll();
             StreamHandler.WriteMemoryStreamToDisk(ms, docxTarget);
         }
@@ -128,7 +135,7 @@ namespace DocXToPdfConverter
         ////string docxSource = filename with path
         private void GenerateReportFromDocxToPdf(string docxSource, string pdfTarget, Placeholders rep)
         {
-            var docx = new DocXHandler(docxSource, rep);
+            var docx = new DocXHandler(docxSource, rep, _processOffice2007Compatible);
             var ms = docx.ReplaceAll();
             var tmpFile = Path.Combine(Path.GetDirectoryName(pdfTarget), Path.GetFileNameWithoutExtension(pdfTarget) + Guid.NewGuid().ToString().Substring(0, 10) + ".docx");
             StreamHandler.WriteMemoryStreamToDisk(ms, tmpFile);
@@ -139,7 +146,7 @@ namespace DocXToPdfConverter
 
         private void GenerateReportFromDocxToHtml(string docxSource, string htmlTarget, Placeholders rep)
         {
-            var docx = new DocXHandler(docxSource, rep);
+            var docx = new DocXHandler(docxSource, rep, _processOffice2007Compatible);
             var ms = docx.ReplaceAll();
             var tmpFile = Path.Combine(Path.GetDirectoryName(htmlTarget), Path.GetFileNameWithoutExtension(docxSource) + Guid.NewGuid().ToString().Substring(0, 10) + ".docx");
             StreamHandler.WriteMemoryStreamToDisk(ms, tmpFile);

--- a/ExampleApplication/Program.cs
+++ b/ExampleApplication/Program.cs
@@ -140,7 +140,7 @@ namespace ExampleApplication
 
             //Most important: give the full path to the soffice.exe file including soffice.exe.
             //Don't know how that would be named on Linux...
-            var test = new ReportGenerator(locationOfLibreOfficeSoffice);
+            var test = new ReportGenerator(locationOfLibreOfficeSoffice, processOffice2007Compatible: true);
 
             //Convert from HTML to HTML
             test.Convert(htmlLocation, Path.Combine(Path.GetDirectoryName(htmlLocation), "Test-HTML-page-out.html"), placeholders);


### PR DESCRIPTION
When converting docx to docx and adding images, then Microsoft Word may complain that the document contains unreadable content and asks to fix this document. That is bad, if the generated docx file has to be processed automatically within a word macro.
This option now allows to generates a docx, that is office 2007 compatible and does not cause that messasgeboxes.