### PR TITLE
update to dotnet7, removed System.Drawing.Common

### DIFF
--- a/DocXToPdfConverter/DocXToPdfConverter.csproj
+++ b/DocXToPdfConverter/DocXToPdfConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -19,7 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.10.0-beta0002" />
-    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+    <PackageReference Include="IronSoftware.System.Drawing" Version="2023.7.1" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
   </ItemGroup>
 
 </Project>

--- a/DocXToPdfConverter/DocXToPdfHandlers/ImageHandler.cs
+++ b/DocXToPdfConverter/DocXToPdfHandlers/ImageHandler.cs
@@ -1,18 +1,17 @@
 ﻿using System;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using DocumentFormat.OpenXml.Packaging;
+using IronSoftware.Drawing;
+using static IronSoftware.Drawing.AnyBitmap;
 
 namespace DocXToPdfConverter.DocXToPdfHandlers
 {
     public static class ImageHandler
     {
-
-        public static Image GetImage(this MemoryStream ms)
+        public static AnyBitmap GetImage(this MemoryStream ms)
         {
             ms.Position = 0;
-            var image = Image.FromStream(ms);
+            var image = AnyBitmap.FromStream(ms);
             ms.Position = 0;
             return image;
         }
@@ -20,28 +19,28 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
         public static ImagePartType GetImagePartType(this MemoryStream stream)
         {
             stream.Position = 0;
-            using (var image = Image.FromStream(stream))
+            using (var image = AnyBitmap.FromStream(stream))
             {
                 stream.Position = 0;
 
 
-                if (ImageFormat.Jpeg.Equals(image.RawFormat))
+                if (ImageFormat.Jpeg.Equals(image.GetImageFormat()))
                 {
                     return ImagePartType.Jpeg;
                 }
-                else if (ImageFormat.Png.Equals(image.RawFormat))
+                else if (ImageFormat.Png.Equals(image.GetImageFormat()))
                 {
                     return ImagePartType.Png;
                 }
-                else if (ImageFormat.Gif.Equals(image.RawFormat))
+                else if (ImageFormat.Gif.Equals(image.GetImageFormat()))
                 {
                     return ImagePartType.Gif;
                 }
-                else if (ImageFormat.Bmp.Equals(image.RawFormat))
+                else if (ImageFormat.Bmp.Equals(image.GetImageFormat()))
                 {
                     return ImagePartType.Bmp;
                 }
-                else if (ImageFormat.Tiff.Equals(image.RawFormat))
+                else if (ImageFormat.Tiff.Equals(image.GetImageFormat()))
                 {
                     return ImagePartType.Tiff;
                 }
@@ -53,27 +52,27 @@ namespace DocXToPdfConverter.DocXToPdfHandlers
         public static string GetImageType(this MemoryStream stream)
         {
             stream.Position = 0;
-            using (var image = Image.FromStream(stream))
+            using (var image = AnyBitmap.FromStream(stream))
             {
                 stream.Position = 0;
 
-                if (ImageFormat.Jpeg.Equals(image.RawFormat))
+                if (ImageFormat.Jpeg.Equals(image.GetImageFormat()))
                 {
                     return "jpeg";
                 }
-                else if (ImageFormat.Png.Equals(image.RawFormat))
+                else if (ImageFormat.Png.Equals(image.GetImageFormat()))
                 {
                     return "png";
                 }
-                else if (ImageFormat.Gif.Equals(image.RawFormat))
+                else if (ImageFormat.Gif.Equals(image.GetImageFormat()))
                 {
                     return "gif";
                 }
-                else if (ImageFormat.Bmp.Equals(image.RawFormat))
+                else if (ImageFormat.Bmp.Equals(image.GetImageFormat()))
                 {
                     return "bmp";
                 }
-                else if (ImageFormat.Tiff.Equals(image.RawFormat))
+                else if (ImageFormat.Tiff.Equals(image.GetImageFormat()))
                 {
                     return "tiff";
                 }

--- a/DocXToPdfConverter/Documentation/Readme.md
+++ b/DocXToPdfConverter/Documentation/Readme.md
@@ -28,16 +28,16 @@ Report from DOCX / HTML to PDF Converter can parse the source document and intro
 Don't get scared away that I use LibreOffice, it is easier than you may think!
 1. LibreOffice - just get the PORTABLE EDITION as you don't screw up your webserver with an installation. The portable version just runs without any installation. We need LibreOffice for converting from DOCX or from HTML to PDF and DOCX, etc
 
-2. Nuget: 
-* Microsoft.NetCore.App
+2. Nuget:
 * Document.Format.OpenXml
-* System.Drawing.Common
+* IronSoftware.System.Drawing;
+* SkiaSharp
 
 3. The OpenXml PowerTools (thanks to Eric White for this great work), which I already included into the project, the whole code!
 
 ## Get started here!
 
-1. Add dependencies to a) Document.Format.OpenXml (by Microsoft). For the OpenXml Powertools by Eric White (which are already included in the project), add System.Drawing.Common (for .NET Core). The regular System.Drawing won't work!
+1. Add dependencies to a) Document.Format.OpenXml (by Microsoft). For the OpenXml Powertools by Eric White (which are already included in the project).
 
 2. Download LibreOffice (https://www.libreoffice.org/download/portable-versions/). I recommend the portable edition as it does not install anything in your server. It is like unzipping files onto your harddrive. Note the path to "soffice.exe" (I don't know what the file is called in Linux / MacOS, probably just soffice. It is an executable to run a headless, mute version of LibreOffice for conversion processes). On my Windows machine, it is under: C:\PortableApps\LibreOfficePortable\App\libreoffice\program\soffice.exe. 
 

--- a/DocXToPdfConverter/OpenXmlPowerTools/ColorParser.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/ColorParser.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-using System.Drawing;
+using IronSoftware.Drawing;
 
 namespace OpenXmlPowerTools
 {
@@ -18,7 +17,7 @@ namespace OpenXmlPowerTools
             {
                 color = Color.FromName(name);
 
-                return color.IsNamedColor;
+                return color != null;
             }
             catch
             {

--- a/DocXToPdfConverter/OpenXmlPowerTools/Comparer/WmlComparer.Private.NestedTypes.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/Comparer/WmlComparer.Private.NestedTypes.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Drawing;
+using IronSoftware.Drawing;
 using System.Xml.Linq;
 
 namespace OpenXmlPowerTools

--- a/DocXToPdfConverter/OpenXmlPowerTools/Comparer/WmlRevisedDocumentInfo.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/Comparer/WmlRevisedDocumentInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Drawing;
+using IronSoftware.Drawing;
 
 namespace OpenXmlPowerTools
 {

--- a/DocXToPdfConverter/OpenXmlPowerTools/FontFamily.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/FontFamily.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using SkiaSharp;
+
+namespace DocXToPdfConverter
+{
+    public static class FontFamily
+    {
+        public static IEnumerable<string> GetFontFamilies()
+        {
+            using (var fontManager = SKFontManager.Default)
+            {
+                return fontManager.FontFamilies;
+            }
+        }
+    }
+}

--- a/DocXToPdfConverter/OpenXmlPowerTools/FormattingAssembler.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/FormattingAssembler.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
-using System.Drawing;
+using IronSoftware.Drawing;
 
 namespace OpenXmlPowerTools
 {

--- a/DocXToPdfConverter/OpenXmlPowerTools/HtmlToWmlConverter.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/HtmlToWmlConverter.cs
@@ -2,17 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
-using OpenXmlPowerTools;
 using OpenXmlPowerTools.HtmlToWml;
-using OpenXmlPowerTools.HtmlToWml.CSS;
 using System.Text.RegularExpressions;
 
 namespace OpenXmlPowerTools

--- a/DocXToPdfConverter/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/HtmlToWmlConverterCore.cs
@@ -98,8 +98,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -109,6 +107,8 @@ using OpenXmlPowerTools;
 using OpenXmlPowerTools.HtmlToWml;
 using OpenXmlPowerTools.HtmlToWml.CSS;
 using System.Text.RegularExpressions;
+using IronSoftware.Drawing;
+using DocXToPdfConverter;
 
 namespace OpenXmlPowerTools.HtmlToWml
 {
@@ -1159,10 +1159,10 @@ namespace OpenXmlPowerTools.HtmlToWml
                 return 0;
 
             // in theory, all unknown fonts are found by the above test, but if not...
-            FontFamily ff;
+            string ff;
             try
             {
-                ff = new FontFamily(fontName);
+                ff = (fontName);
             }
             catch (ArgumentException)
             {
@@ -1885,9 +1885,9 @@ namespace OpenXmlPowerTools.HtmlToWml
                 if (_knownFamilies == null)
                 {
                     _knownFamilies = new HashSet<string>();
-                    var families = FontFamily.Families;
+                    var families = FontFamily.GetFontFamilies();
                     foreach (var fam in families)
-                        _knownFamilies.Add(fam.Name);
+                        _knownFamilies.Add(fam);
                 }
                 return _knownFamilies;
             }
@@ -2279,7 +2279,7 @@ namespace OpenXmlPowerTools.HtmlToWml
         {
             string srcAttribute = (string)element.Attribute(XhtmlNoNamespace.src);
             byte[] ba = null;
-            Bitmap bmp = null;
+            AnyBitmap bmp = null;
 
             if (srcAttribute.StartsWith("data:"))
             {
@@ -2289,14 +2289,14 @@ namespace OpenXmlPowerTools.HtmlToWml
                 ba = Convert.FromBase64String(base64);
                 using (MemoryStream ms = new MemoryStream(ba))
                 {
-                    bmp = new Bitmap(ms);
+                    bmp = new AnyBitmap(ms);
                 }
             }
             else
             {
                 try
                 {
-                    bmp = new Bitmap(settings.BaseUriForImages + "/" + srcAttribute);
+                    bmp = new AnyBitmap(settings.BaseUriForImages + "/" + srcAttribute);
                 }
                 catch (ArgumentException)
                 {
@@ -2307,13 +2307,13 @@ namespace OpenXmlPowerTools.HtmlToWml
                     return null;
                 }
                 MemoryStream ms = new MemoryStream();
-                bmp.Save(ms, bmp.RawFormat);
+                bmp.ExportStream(ms, bmp.GetImageFormat());
                 ba = ms.ToArray();
             }
 
             MainDocumentPart mdp = wDoc.MainDocumentPart;
             string rId = "R" + Guid.NewGuid().ToString().Replace("-", "");
-            ImagePartType ipt = ImagePartType.Png;
+            var ipt = ImagePartType.Png;
             ImagePart newPart = mdp.AddImagePart(ipt, rId);
             using (Stream s = newPart.GetStream(FileMode.Create, FileAccess.ReadWrite))
                 s.Write(ba, 0, ba.GetUpperBound(0) + 1);
@@ -2352,7 +2352,7 @@ namespace OpenXmlPowerTools.HtmlToWml
             return null;
         }
 
-        private static XElement GetImageAsInline(XElement element, HtmlToWmlConverterSettings settings, WordprocessingDocument wDoc, Bitmap bmp,
+        private static XElement GetImageAsInline(XElement element, HtmlToWmlConverterSettings settings, WordprocessingDocument wDoc, AnyBitmap bmp,
             string rId, int pictureId, string pictureDescription)
         {
             XElement inline = new XElement(WP.inline, // 20.4.2.8
@@ -2369,7 +2369,7 @@ namespace OpenXmlPowerTools.HtmlToWml
             return inline;
         }
 
-        private static XElement GetImageAsAnchor(XElement element, HtmlToWmlConverterSettings settings, WordprocessingDocument wDoc, Bitmap bmp,
+        private static XElement GetImageAsAnchor(XElement element, HtmlToWmlConverterSettings settings, WordprocessingDocument wDoc, AnyBitmap bmp,
             string rId, string floatValue, int pictureId, string pictureDescription)
         {
             Emu minDistFromEdge = (long)(0.125 * Emu.s_EmusPerInch);
@@ -2550,13 +2550,12 @@ namespace OpenXmlPowerTools.HtmlToWml
                 new XElement(W.noProof));
         }
 
-        private static SizeEmu GetImageSizeInEmus(XElement img, Bitmap bmp)
+        private static SizeEmu GetImageSizeInEmus(XElement img, AnyBitmap bmp)
         {
-            double hres = bmp.HorizontalResolution;
-            double vres = bmp.VerticalResolution;
-            Size s = bmp.Size;
-            Emu cx = (long)((double)(s.Width / hres) * (double)Emu.s_EmusPerInch);
-            Emu cy = (long)((double)(s.Height / vres) * (double)Emu.s_EmusPerInch);
+            double? hres = bmp.HorizontalResolution;
+            double? vres = bmp.VerticalResolution;
+            Emu cx = (long)((double)(bmp.Width / hres) * (double)Emu.s_EmusPerInch);
+            Emu cy = (long)((double)(bmp.Height / vres) * (double)Emu.s_EmusPerInch);
 
             CssExpression width = img.GetProp("width");
             CssExpression height = img.GetProp("height");
@@ -2583,7 +2582,7 @@ namespace OpenXmlPowerTools.HtmlToWml
             return new SizeEmu(cx, cy);
         }
 
-        private static XElement GetImageExtent(XElement img, Bitmap bmp)
+        private static XElement GetImageExtent(XElement img, AnyBitmap bmp)
         {
             SizeEmu szEmu = GetImageSizeInEmus(img, bmp);
             return new XElement(WP.extent,
@@ -2616,7 +2615,7 @@ namespace OpenXmlPowerTools.HtmlToWml
                     new XAttribute(NoNamespace.noChangeAspect, 1)));
         }
 
-        private static XElement GetGraphicForImage(XElement element, string rId, Bitmap bmp, int pictureId, string pictureDescription)
+        private static XElement GetGraphicForImage(XElement element, string rId, AnyBitmap bmp, int pictureId, string pictureDescription)
         {
             SizeEmu szEmu = GetImageSizeInEmus(element, bmp);
             XElement graphic = new XElement(A.graphic,

--- a/DocXToPdfConverter/OpenXmlPowerTools/HtmlToWmlCssParser.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/HtmlToWmlCssParser.cs
@@ -17,7 +17,7 @@ Resource Center and Documentation: http://openxmldeveloper.org/wiki/w/wiki/power
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Drawing;
+using IronSoftware.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/DocXToPdfConverter/OpenXmlPowerTools/OxPtHelpers.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/OxPtHelpers.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -11,10 +10,10 @@ using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using DocumentFormat.OpenXml.Validation;
-using OpenXmlPowerTools;
 using System.Text;
 using DocumentFormat.OpenXml;
-using System.Drawing.Imaging;
+using IronSoftware.Drawing;
+using static IronSoftware.Drawing.AnyBitmap;
 
 namespace OpenXmlPowerTools
 {
@@ -374,7 +373,7 @@ AAsACwDBAgAAbCwAAAAA";
                                 localDirInfo.Create();
                             ++imageCounter;
                             string extension = imageInfo.ContentType.Split('/')[1].ToLower();
-                            ImageFormat imageFormat = null;
+                            ImageFormat? imageFormat = null;
                             if (extension == "png")
                             {
                                 // Convert png to jpeg.
@@ -408,7 +407,7 @@ AAsACwDBAgAAbCwAAAAA";
                                 imageCounter.ToString() + "." + extension;
                             try
                             {
-                                imageInfo.Bitmap.Save(imageFileName, imageFormat);
+                                imageInfo.Bitmap.SaveAs(imageFileName, imageFormat.Value);
                             }
                             catch (System.Runtime.InteropServices.ExternalException)
                             {

--- a/DocXToPdfConverter/OpenXmlPowerTools/Previous/WmlComparer.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/Previous/WmlComparer.cs
@@ -10,7 +10,7 @@ using System.IO.Packaging;
 using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
-using System.Drawing;
+using IronSoftware.Drawing;
 using System.Security.Cryptography;
 using OpenXmlPowerTools;
 

--- a/DocXToPdfConverter/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -12,9 +12,8 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Collections.Generic;
 using DocumentFormat.OpenXml.Packaging;
-using System.Drawing;
-using Font = System.Drawing.Font;
-using FontFamily = System.Drawing.FontFamily;
+using IronSoftware.Drawing;
+using DocXToPdfConverter;
 
 // ReSharper disable InconsistentNaming
 
@@ -637,9 +636,9 @@ namespace OpenXmlPowerTools
             if (KnownFamilies == null)
             {
                 KnownFamilies = new HashSet<string>();
-                var families = FontFamily.Families;
+                var families = FontFamily.GetFontFamilies();
                 foreach (var fam in families)
-                    KnownFamilies.Add(fam.Name);
+                    KnownFamilies.Add(fam);
             }
 
             var fontName = (string)r.Attribute(PtOpenXml.pt + "FontName");
@@ -668,10 +667,10 @@ namespace OpenXmlPowerTools
             if (!KnownFamilies.Contains(fontName))
                 return 0;
             // in theory, all unknown fonts are found by the above test, but if not...
-            FontFamily ff;
+            string ff;
             try
             {
-                ff = new FontFamily(fontName);
+                ff = (fontName);
             }
             catch (ArgumentException)
             {

--- a/DocXToPdfConverter/OpenXmlPowerTools/SmlCellFormatter.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/SmlCellFormatter.cs
@@ -3,14 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
-using DocumentFormat.OpenXml.Packaging;
 
 namespace OpenXmlPowerTools
 {

--- a/DocXToPdfConverter/OpenXmlPowerTools/SmlDataRetriever.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/SmlDataRetriever.cs
@@ -3,15 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
-using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using System.IO;
-using OpenXmlPowerTools;
 
 namespace OpenXmlPowerTools
 {

--- a/DocXToPdfConverter/OpenXmlPowerTools/SmlToHtmlConverter.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/SmlToHtmlConverter.cs
@@ -4,13 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using System.IO;
+using DocXToPdfConverter;
 
 namespace OpenXmlPowerTools
 {
@@ -236,9 +235,9 @@ namespace OpenXmlPowerTools
                 if (_knownFamilies == null)
                 {
                     _knownFamilies = new HashSet<string>();
-                    var families = FontFamily.Families;
+                    var families = FontFamily.GetFontFamilies();
                     foreach (var fam in families)
-                        _knownFamilies.Add(fam.Name);
+                        _knownFamilies.Add(fam);
                 }
                 return _knownFamilies;
             }

--- a/DocXToPdfConverter/OpenXmlPowerTools/WmlToHtmlConverter.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/WmlToHtmlConverter.cs
@@ -4,12 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
+using DocXToPdfConverter;
+using IronSoftware.Drawing;
 
 // 200e lrm - LTR
 // 200f rlm - RTL
@@ -120,7 +121,7 @@ namespace OpenXmlPowerTools
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     public class ImageInfo
     {
-        public Bitmap Bitmap;
+        public AnyBitmap Bitmap;
         public XAttribute ImgStyleAttribute;
         public string ContentType;
         public XElement DrawingElement;
@@ -2247,9 +2248,9 @@ namespace OpenXmlPowerTools
                 if (_knownFamilies == null)
                 {
                     _knownFamilies = new HashSet<string>();
-                    var families = FontFamily.Families;
+                    var families = FontFamily.GetFontFamilies();
                     foreach (var fam in families)
-                        _knownFamilies.Add(fam.Name);
+                        _knownFamilies.Add(fam);
                 }
                 return _knownFamilies;
             }
@@ -2275,10 +2276,10 @@ namespace OpenXmlPowerTools
                 return 0;
 
             // in theory, all unknown fonts are found by the above test, but if not...
-            FontFamily ff;
+            string ff;
             try
             {
-                ff = new FontFamily(fontName);
+                ff = (fontName);
             }
             catch (ArgumentException)
             {
@@ -3078,7 +3079,7 @@ namespace OpenXmlPowerTools
                 return null;
 
             using (var partStream = imagePart.GetStream())
-            using (var bitmap = new Bitmap(partStream))
+            using (var bitmap = new AnyBitmap(partStream))
             {
                 if (extentCx != null && extentCy != null)
                 {
@@ -3144,7 +3145,7 @@ namespace OpenXmlPowerTools
                 {
                     try
                     {
-                        using (var bitmap = new Bitmap(partStream))
+                        using (var bitmap = new AnyBitmap(partStream))
                         {
                             var imageInfo = new ImageInfo()
                             {

--- a/DocXToPdfConverter/OpenXmlPowerTools/WmlToXml.cs
+++ b/DocXToPdfConverter/OpenXmlPowerTools/WmlToXml.cs
@@ -17,7 +17,6 @@ using System.Text.RegularExpressions;
 using System.IO;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
-using System.Drawing;
 
 namespace OpenXmlPowerTools
 {

--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ExampleApplication/Program.cs
+++ b/ExampleApplication/Program.cs
@@ -37,7 +37,7 @@ namespace ExampleApplication
             //or anything you have in Linux...
 
             string locationOfLibreOfficeSoffice =
-                @"F:\PortableApps\LibreOfficePortable\App\libreoffice\program\soffice.exe";
+                @"C:\utils\LibreOfficePortable\App\libreoffice\program\soffice.exe";
 
 
             //This is only to get this example to work (find the word docx and the html file, which were


### PR DESCRIPTION
Added support for dotnet7.

Since [`System.Drawing.Common` doesn't work in linux with dotnet7](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/7.0/system-drawing)
lib is now using `IronSoftware.System.Drawing` and `SkiaSharp`